### PR TITLE
precommit: `terraform fmt` makes changes on disk

### DIFF
--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -12,7 +12,7 @@ export PATH=$PATH:/usr/local/bin
 FMT_ERROR=0
 
 for file in "$@"; do
-  terraform fmt -diff -check "$file" || FMT_ERROR=$?
+  terraform fmt "$file" || FMT_ERROR=$?
 done
 
 # reset path to the original value

--- a/memfault-patch.sh
+++ b/memfault-patch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i -e 's/terraform fmt -diff -check/terraform fmt/' hooks/terraform-fmt.sh


### PR DESCRIPTION
 ### Issues Addressed
Most of our pre-commit checks just make the changes that are rote, obvious
changes. Not `terraform fmt`! Instead, it just reports the error and exits,
meaning you have to fix the issue manually. And there's no reason for it, it's
just someone decided to do it that way and the maintainers won't switch it
back. Comment thread: https://github.com/gruntwork-io/pre-commit/issues/48

 ### Summary of Changes
I patched precommit to use the expected behavior. I included a shell
file to add the patch so it's easy to stay up-to-date with upstream.

 ### Test Plan
- Tested that precommit now automatically updates terraform files when
  using this branch for precommit.